### PR TITLE
Add Kit timeline page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -170,6 +170,10 @@ export default function App() {
         <Link className="link" to="/stats/">
           Stats
         </Link>
+        |
+        <Link className="link" to="/timeline/">
+          Timeline
+        </Link>
       </nav>
     </>
   );

--- a/src/Timeline.js
+++ b/src/Timeline.js
@@ -1,0 +1,101 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import kits from "./kits.json";
+
+const typeOrder = { Home: 0, Away: 1, Third: 2 };
+
+const buildTimeline = () => {
+  const byTeam = {};
+
+  kits.forEach(kit => {
+    if (!byTeam[kit.team]) byTeam[kit.team] = {};
+    if (!byTeam[kit.team][kit.year]) byTeam[kit.team][kit.year] = [];
+    byTeam[kit.team][kit.year].push(kit);
+  });
+
+  Object.keys(byTeam).forEach(team => {
+    Object.keys(byTeam[team]).forEach(year => {
+      byTeam[team][year].sort(
+        (a, b) => (typeOrder[a.type] || 99) - (typeOrder[b.type] || 99)
+      );
+    });
+  });
+
+  return byTeam;
+};
+
+export default function Timeline() {
+  const timeline = useMemo(() => buildTimeline(), []);
+
+  const teams = useMemo(
+    () => Object.keys(timeline).sort((a, b) => a.localeCompare(b)),
+    [timeline]
+  );
+
+  const [selectedTeam, setSelectedTeam] = useState(teams[0]);
+
+  const years = useMemo(
+    () =>
+      Object.keys(timeline[selectedTeam] || {}).sort(
+        (a, b) => Number(a) - Number(b)
+      ),
+    [timeline, selectedTeam]
+  );
+
+  return (
+    <>
+      <Link style={{ textDecoration: "none" }} to="/">
+        <h1>KIT PICS</h1>
+      </Link>
+
+      <div id="timeline">
+        <div className="timeline-controls">
+          <label htmlFor="team-select">Team</label>
+          <select
+            id="team-select"
+            value={selectedTeam}
+            onChange={e => setSelectedTeam(e.target.value)}
+          >
+            {teams.map(team => (
+              <option key={team} value={team}>
+                {team}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <ol className="timeline-years">
+          {years.map(year => (
+            <li key={year} className="timeline-year">
+              <span className="timeline-year-label">{year}</span>
+
+              <div className="timeline-year-kits">
+                {timeline[selectedTeam][year].map((kit, i) => (
+                  <figure key={i} className="timeline-kit">
+                    <img src={kit.src} alt={kit.alt} />
+                    <figcaption>{kit.type}</figcaption>
+                  </figure>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        {years.length === 0 && (
+          <p>No kits found for this team.</p>
+        )}
+      </div>
+
+      <nav>
+        <Link className="link" to="/about/">
+          About
+        </Link>
+        |
+        <Link className="link" to="/stats/">
+          Stats
+        </Link>
+      </nav>
+    </>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import "./style.css";
 import About from "./About";
 import App from "./App";
 import Stats from "./Stats";
+import Timeline from "./Timeline";
 import * as serviceWorker from "./serviceWorker";
 
 const AppRouter = () => {
@@ -13,6 +14,7 @@ const AppRouter = () => {
       <Route path="/" exact component={App} />
       <Route path="/about/" component={About} />
       <Route path="/stats/" component={Stats} />
+      <Route path="/timeline/" component={Timeline} />
     </BrowserRouter>
   );
 };

--- a/src/style.css
+++ b/src/style.css
@@ -195,6 +195,111 @@ p {
   line-height: 24px;
 }
 
+#timeline {
+  height: 82vh;
+  overflow-y: scroll;
+  padding-bottom: 32px;
+}
+
+.timeline-controls {
+  margin: 24px 32px 16px;
+  display: flex;
+  flex-direction: column;
+  color: white;
+}
+
+.timeline-controls > label {
+  font-size: 12px;
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+  opacity: 0.7;
+}
+
+.timeline-controls > select {
+  width: 100%;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 16px;
+  letter-spacing: 1px;
+  color: #0e704f;
+  background: white;
+  border: 4px double black;
+  border-radius: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.timeline-years {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.timeline-years::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 56px;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.timeline-year {
+  position: relative;
+  padding: 8px 32px 8px 88px;
+  margin: 0;
+}
+
+.timeline-year-label {
+  position: absolute;
+  left: 16px;
+  top: 18px;
+  width: 80px;
+  color: white;
+  font-size: 18px;
+  letter-spacing: 1px;
+  background: #0e704f;
+  padding: 2px 0;
+  z-index: 1;
+}
+
+.timeline-year-kits {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.timeline-kit {
+  flex: 0 0 auto;
+  margin: 0;
+  background: white;
+  border: 4px double black;
+  border-radius: 4px;
+  padding: 8px 8px 4px;
+  width: 96px;
+  text-align: center;
+}
+
+.timeline-kit > img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+
+.timeline-kit > figcaption {
+  color: goldenrod;
+  font-size: 12px;
+  letter-spacing: 1px;
+  margin-top: 4px;
+}
+
 @media only screen and (max-width: 420px) {
   h1 {
     font-size: 32px;


### PR DESCRIPTION
## Summary
- New `/timeline` route: per-team visual history showing every kit chronologically by year
- Team dropdown selector; kits within a season ordered Home → Away → Third
- Vertical year-stamped timeline with a horizontal kit strip per season
- Linked from the home page nav alongside About and Stats

## Test plan
- [ ] `yarn start` and visit `/timeline/`
- [ ] Confirm all 48 teams appear in the dropdown
- [ ] Switch teams and confirm years render ascending with correct kits
- [ ] Kit strip scrolls horizontally on narrow viewports
- [ ] Nav link from home works; "KIT PICS" header links back to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)