### PR TITLE
Add per-team and per-season liked kits breakdown to Stats

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -16,6 +16,9 @@ const getStats = () => {
   const dislikedYears = {};
   const likedYears = {};
 
+  const likedKitsByTeam = {};
+  const likedKitsByYear = {};
+
   let awayKits = 0;
   let homeKits = 0;
 
@@ -64,6 +67,26 @@ const getStats = () => {
       likedYears[kit.year] += 1;
     }
 
+    if (!likedKitsByTeam[kit.team]) {
+      likedKitsByTeam[kit.team] = [];
+    }
+    likedKitsByTeam[kit.team].push({
+      alt: kit.alt,
+      src: kit.src,
+      type: kit.type,
+      year: kit.year
+    });
+
+    if (!likedKitsByYear[kit.year]) {
+      likedKitsByYear[kit.year] = [];
+    }
+    likedKitsByYear[kit.year].push({
+      alt: kit.alt,
+      src: kit.src,
+      team: kit.team,
+      type: kit.type
+    });
+
     if (kit.type === "Home") {
       homeKits += 1;
     } else if (kit.type === "Away") {
@@ -94,10 +117,20 @@ const getStats = () => {
     (a, b) => likedYears[a] < likedYears[b]
   )[0];
 
+  const likedKitsByTeamSorted = Object.keys(likedKitsByTeam)
+    .sort()
+    .map(team => ({ team, kits: likedKitsByTeam[team] }));
+
+  const likedKitsByYearSorted = Object.keys(likedKitsByYear)
+    .sort((a, b) => Number(b) - Number(a))
+    .map(year => ({ year, kits: likedKitsByYear[year] }));
+
   return {
     homeOrAway: homeOrAway,
     dislikedKits: dislikedKitsGallery,
     likedKits: likedKitsGallery,
+    likedKitsByTeam: likedKitsByTeamSorted,
+    likedKitsByYear: likedKitsByYearSorted,
     mostDislikedTeam: mostDislikedTeam,
     mostDislikedYear: mostDislikedYear,
     mostLikedTeam: mostLikedTeam,
@@ -146,6 +179,44 @@ export default function Stats() {
             <span>{stats.homeOrAway}</span>
           </li>
         </ul>
+
+        <h4>Liked kits by team</h4>
+
+        {stats.likedKitsByTeam.length > 0 ? (
+          stats.likedKitsByTeam.map(group => (
+            <div key={group.team} className="kits-group">
+              <p className="kits-group-label">
+                {group.team} ({group.kits.length})
+              </p>
+              <div className="kits-gallery">
+                {group.kits.map((kit, i) => (
+                  <img key={i} src={kit.src} alt={kit.alt} />
+                ))}
+              </div>
+            </div>
+          ))
+        ) : (
+          <p>No kits liked yet!</p>
+        )}
+
+        <h4>Liked kits by season</h4>
+
+        {stats.likedKitsByYear.length > 0 ? (
+          stats.likedKitsByYear.map(group => (
+            <div key={group.year} className="kits-group">
+              <p className="kits-group-label">
+                {group.year} ({group.kits.length})
+              </p>
+              <div className="kits-gallery">
+                {group.kits.map((kit, i) => (
+                  <img key={i} src={kit.src} alt={kit.alt} />
+                ))}
+              </div>
+            </div>
+          ))
+        ) : (
+          <p>No kits liked yet!</p>
+        )}
 
         <h4>Liked kits ({stats.likedKits.length})</h4>
 

--- a/src/style.css
+++ b/src/style.css
@@ -188,6 +188,23 @@ p {
   display: inline-block;
 }
 
+.kits-group {
+  margin-top: 16px;
+}
+
+.kits-group > .kits-gallery {
+  height: 80px;
+  margin: 8px 32px 16px;
+}
+
+.kits-group-label {
+  margin: 0 32px;
+  color: white;
+  font-size: 12px;
+  letter-spacing: 1px;
+  opacity: 0.7;
+}
+
 .about {
   margin: 32px;
   font-size: 18px;


### PR DESCRIPTION
## Summary
- Group each user's liked kits by team and by season on the Stats page, showing which kits they picked in each team/season context.
- Keep the existing overall stats (top team, best year, home/away, full liked/disliked galleries) intact.
- Add light styling to render the grouped galleries with a label above each row.

## Test plan
- [ ] Like a mix of kits across several teams and seasons, then open /stats/
- [ ] Verify a \"Liked kits by team\" row appears for each team with that team's liked kits
- [ ] Verify a \"Liked kits by season\" row appears for each season (newest first) with that season's liked kits
- [ ] Verify the overall \"Liked kits\" and \"Disliked kits\" sections still render as before
- [ ] With no likes yet, verify \"No kits liked yet!\" shows under both new sections