### PR TITLE
Add Kit timeline page

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -251,6 +251,8 @@ export const renderApp = (root: HTMLElement): (() => void) => {
       <a class="link" href="/about/" data-link>About</a>
       |
       <a class="link" href="/stats/" data-link>Stats</a>
+      |
+      <a class="link" href="/timeline/" data-link>Timeline</a>
     </nav>
   `;
 

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -1,0 +1,122 @@
+import kitsData from "./kits.json";
+
+interface Kit {
+  src: string;
+  alt: string;
+  team: string;
+  year: string;
+  type: string;
+}
+
+const kits = kitsData as Kit[];
+
+const typeOrder: Record<string, number> = { Home: 0, Away: 1, Third: 2 };
+const rank = (type: string) =>
+  type in typeOrder ? typeOrder[type] : 99;
+
+type TimelineData = Record<string, Record<string, Kit[]>>;
+
+const buildTimeline = (): TimelineData => {
+  const byTeam: TimelineData = {};
+  for (const kit of kits) {
+    if (!byTeam[kit.team]) byTeam[kit.team] = {};
+    if (!byTeam[kit.team][kit.year]) byTeam[kit.team][kit.year] = [];
+    byTeam[kit.team][kit.year].push(kit);
+  }
+  for (const team in byTeam) {
+    for (const year in byTeam[team]) {
+      byTeam[team][year].sort((a, b) => rank(a.type) - rank(b.type));
+    }
+  }
+  return byTeam;
+};
+
+const escapeAttr = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const escapeText = (value: string) =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const yearsMarkup = (yearMap: Record<string, Kit[]>) => {
+  const years = Object.keys(yearMap).sort((a, b) => Number(a) - Number(b));
+  if (years.length === 0) return `<p>No kits found for this team.</p>`;
+  return `
+    <ol class="timeline-years">
+      ${years
+        .map(
+          (year) => `
+        <li class="timeline-year">
+          <span class="timeline-year-label">${escapeText(year)}</span>
+          <div class="timeline-year-kits">
+            ${yearMap[year]
+              .map(
+                (kit) => `
+              <figure class="timeline-kit">
+                <img src="${escapeAttr(kit.src)}" alt="${escapeAttr(kit.alt)}" />
+                <figcaption>${escapeText(kit.type)}</figcaption>
+              </figure>
+            `,
+              )
+              .join("")}
+          </div>
+        </li>
+      `,
+        )
+        .join("")}
+    </ol>
+  `;
+};
+
+export const renderTimeline = (root: HTMLElement): (() => void) => {
+  const timeline = buildTimeline();
+  const teams = Object.keys(timeline).sort((a, b) => a.localeCompare(b));
+  const initialTeam = teams[0] ?? "";
+
+  root.innerHTML = `
+    <a href="/" data-link style="text-decoration: none">
+      <h1>KIT PICS</h1>
+    </a>
+
+    <div id="timeline">
+      <div class="timeline-controls">
+        <label for="team-select">Team</label>
+        <select id="team-select">
+          ${teams
+            .map(
+              (team) =>
+                `<option value="${escapeAttr(team)}">${escapeText(team)}</option>`,
+            )
+            .join("")}
+        </select>
+      </div>
+
+      <div id="timeline-content">
+        ${teams.length ? yearsMarkup(timeline[initialTeam]) : `<p>No kits found.</p>`}
+      </div>
+    </div>
+
+    <nav>
+      <a class="link" href="/about/" data-link>About</a>
+      |
+      <a class="link" href="/stats/" data-link>Stats</a>
+    </nav>
+  `;
+
+  const select = root.querySelector<HTMLSelectElement>("#team-select");
+  const content = root.querySelector<HTMLDivElement>("#timeline-content");
+
+  const onChange = () => {
+    if (!select || !content) return;
+    content.innerHTML = yearsMarkup(timeline[select.value] ?? {});
+  };
+
+  select?.addEventListener("change", onChange);
+
+  return () => {
+    select?.removeEventListener("change", onChange);
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import { renderApp } from "./App.ts";
 import { renderAbout } from "./About.ts";
 import { renderStats } from "./Stats.ts";
+import { renderTimeline } from "./Timeline.ts";
 
 type Route = (root: HTMLElement) => void | (() => void);
 
 const routes: Array<[RegExp, Route]> = [
   [/^\/about\/?$/, renderAbout],
   [/^\/stats\/?$/, renderStats],
+  [/^\/timeline\/?$/, renderTimeline],
   [/^\/?$/, renderApp],
 ];
 

--- a/src/style.css
+++ b/src/style.css
@@ -205,6 +205,121 @@ p {
   line-height: 24px;
 }
 
+#timeline {
+  height: 82vh;
+  overflow-y: auto;
+  padding-bottom: 32px;
+  scrollbar-width: none;
+}
+
+#timeline::-webkit-scrollbar {
+  display: none;
+}
+
+.timeline-controls {
+  margin: 24px 32px 16px;
+  display: flex;
+  flex-direction: column;
+  color: white;
+}
+
+.timeline-controls > label {
+  font-size: 12px;
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+  opacity: 0.7;
+}
+
+.timeline-controls > select {
+  width: 100%;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 16px;
+  letter-spacing: 1px;
+  color: #0e704f;
+  background: white;
+  border: 4px double black;
+  border-radius: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.timeline-years {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.timeline-years::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 56px;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.timeline-year {
+  position: relative;
+  padding: 8px 32px 8px 112px;
+  margin: 0;
+}
+
+.timeline-year-label {
+  position: absolute;
+  left: 16px;
+  top: 18px;
+  width: 80px;
+  color: white;
+  font-size: 18px;
+  letter-spacing: 1px;
+  background: #0e704f;
+  padding: 2px 0;
+  z-index: 1;
+}
+
+.timeline-year-kits {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  gap: 12px;
+  padding: 8px 0;
+  scrollbar-width: none;
+}
+
+.timeline-year-kits::-webkit-scrollbar {
+  display: none;
+}
+
+.timeline-kit {
+  flex: 0 0 auto;
+  margin: 0;
+  background: white;
+  border: 4px double black;
+  border-radius: 4px;
+  padding: 8px 8px 4px;
+  width: 96px;
+  text-align: center;
+}
+
+.timeline-kit > img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+
+.timeline-kit > figcaption {
+  color: goldenrod;
+  font-size: 12px;
+  letter-spacing: 1px;
+  margin-top: 4px;
+}
+
 @media only screen and (max-width: 420px) {
   h1 {
     font-size: 32px;

--- a/test.ts
+++ b/test.ts
@@ -20,7 +20,15 @@ const staticRoutes: Record<string, string> = {
   "/swipe-right.svg": "./src/swipe-right.svg",
 };
 
-const spaRoutes = new Set(["/", "/about", "/about/", "/stats", "/stats/"]);
+const spaRoutes = new Set([
+  "/",
+  "/about",
+  "/about/",
+  "/stats",
+  "/stats/",
+  "/timeline",
+  "/timeline/",
+]);
 
 const bundled = await buildApp();
 
@@ -116,7 +124,7 @@ await run("home route renders deck", async () => {
   const linkCount = (await view.evaluate(
     "document.querySelectorAll('nav a[data-link]').length",
   )) as number;
-  check(linkCount === 2, `nav renders 2 data-link anchors (got ${linkCount})`);
+  check(linkCount === 3, `nav renders 3 data-link anchors (got ${linkCount})`);
   check((await collectInPageErrors()).length === 0, "no in-page errors on /");
 });
 
@@ -172,6 +180,36 @@ await run("seeded votes flow through to stats page", async () => {
   check(
     (await collectInPageErrors()).length === 0,
     "no in-page errors on seeded /stats/",
+  );
+});
+
+await run("timeline route renders sorted kits", async () => {
+  await view.navigate(`${base}/timeline/`);
+  await installErrorHook();
+  await waitFor(
+    "!!document.getElementById('timeline')",
+    "#timeline container present",
+  );
+  const teamOptions = (await view.evaluate(
+    "document.querySelectorAll('#team-select option').length",
+  )) as number;
+  check(teamOptions > 0, `team select has options (got ${teamOptions})`);
+  const firstYearTypes = (await view.evaluate(
+    "Array.from(document.querySelectorAll('.timeline-year')[0]?.querySelectorAll('.timeline-kit figcaption') ?? []).map((n) => n.textContent)",
+  )) as string[];
+  const order = { Home: 0, Away: 1, Third: 2 } as Record<string, number>;
+  const sorted = firstYearTypes.every(
+    (t, i) =>
+      i === 0 ||
+      (order[t] ?? 99) >= (order[firstYearTypes[i - 1]!] ?? 99),
+  );
+  check(
+    firstYearTypes.length > 0 && sorted,
+    `first year kits sorted Home/Away/Third (got ${JSON.stringify(firstYearTypes)})`,
+  );
+  check(
+    (await collectInPageErrors()).length === 0,
+    "no in-page errors on /timeline/",
   );
 });
 


### PR DESCRIPTION
## Summary
- Add `/timeline/` route: a per-team, year-by-year kit gallery sorted Home → Away → Third
- Port forward from `meeseeks/t9xz3q`, which was cut from a pre-rewrite commit and can't cleanly merge (it touched `.js` files that no longer exist on main after `8b8efde`)
- Fix the ordering bug from the original branch: `typeOrder[type] || 99` incorrectly fell back to 99 for Home (value 0), pushing Home to the end. Replaced with a `rank()` helper that explicitly checks for undefined
- Fix the first-kit overlap: bumped `.timeline-year` left padding so the kit row clears the 96px year-label box

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes, including a new timeline smoke test asserting Home/Away/Third order
- [x] Manual: visit `/timeline/`, confirm the team `<select>` switches year lists and the first kit isn't covered by the year label
- [x] Close/delete `meeseeks/t9xz3q` once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)