### PR TITLE
Add per-team and per-season liked kits breakdown to Stats

### DIFF
--- a/src/Stats.ts
+++ b/src/Stats.ts
@@ -16,10 +16,17 @@ interface GalleryItem {
   team: string;
 }
 
+interface KitGroup {
+  label: string;
+  kits: GalleryItem[];
+}
+
 interface Stats {
   homeOrAway: string;
   dislikedKits: GalleryItem[];
   likedKits: GalleryItem[];
+  likedKitsByTeam: KitGroup[];
+  likedKitsByYear: KitGroup[];
   mostDislikedTeam: string | undefined;
   mostDislikedYear: string | undefined;
   mostLikedTeam: string | undefined;
@@ -53,6 +60,9 @@ const getStats = (): Stats => {
   const dislikedYears: Record<string, number> = {};
   const likedYears: Record<string, number> = {};
 
+  const likedByTeam: Record<string, GalleryItem[]> = {};
+  const likedByYear: Record<string, GalleryItem[]> = {};
+
   let awayKits = 0;
   let homeKits = 0;
 
@@ -67,9 +77,12 @@ const getStats = (): Stats => {
   for (const id of likedIds) {
     const kit = kits[id];
     if (!kit) continue;
-    likedKitsGallery.push({ alt: kit.alt, src: kit.src, team: kit.team });
+    const item = { alt: kit.alt, src: kit.src, team: kit.team };
+    likedKitsGallery.push(item);
     likedTeams[kit.team] = (likedTeams[kit.team] ?? 0) + 1;
     likedYears[kit.year] = (likedYears[kit.year] ?? 0) + 1;
+    (likedByTeam[kit.team] ??= []).push(item);
+    (likedByYear[kit.year] ??= []).push(item);
     if (kit.type === "Home") homeKits += 1;
     else if (kit.type === "Away") awayKits += 1;
   }
@@ -77,10 +90,20 @@ const getStats = (): Stats => {
   dislikedKitsGallery.sort((a, b) => (a.team > b.team ? 1 : -1));
   likedKitsGallery.sort((a, b) => (a.team > b.team ? 1 : -1));
 
+  const likedKitsByTeam: KitGroup[] = Object.keys(likedByTeam)
+    .sort()
+    .map((team) => ({ label: team, kits: likedByTeam[team]! }));
+
+  const likedKitsByYear: KitGroup[] = Object.keys(likedByYear)
+    .sort((a, b) => Number(b) - Number(a))
+    .map((year) => ({ label: year, kits: likedByYear[year]! }));
+
   return {
     homeOrAway: homeKits > awayKits ? "Home" : "Away",
     dislikedKits: dislikedKitsGallery,
     likedKits: likedKitsGallery,
+    likedKitsByTeam,
+    likedKitsByYear,
     mostDislikedTeam: topKey(dislikedTeams),
     mostDislikedYear: topKey(dislikedYears),
     mostLikedTeam: topKey(likedTeams),
@@ -100,6 +123,20 @@ const galleryMarkup = (items: GalleryItem[]) =>
     .map(
       (kit) =>
         `<img src="${escapeAttr(kit.src)}" alt="${escapeAttr(kit.alt)}" />`,
+    )
+    .join("");
+
+const groupsMarkup = (groups: KitGroup[]) =>
+  groups
+    .map(
+      (group) => `
+        <div class="kits-group">
+          <p class="kits-group-label">
+            ${escapeAttr(group.label)} (${group.kits.length})
+          </p>
+          <div class="kits-gallery">${galleryMarkup(group.kits)}</div>
+        </div>
+      `,
     )
     .join("");
 
@@ -134,6 +171,22 @@ export const renderStats = (root: HTMLElement) => {
           <span>${stats.homeOrAway}</span>
         </li>
       </ul>
+
+      <h4>Liked kits by team</h4>
+
+      ${
+        stats.likedKitsByTeam.length > 0
+          ? groupsMarkup(stats.likedKitsByTeam)
+          : `<p>No kits liked yet!</p>`
+      }
+
+      <h4>Liked kits by season</h4>
+
+      ${
+        stats.likedKitsByYear.length > 0
+          ? groupsMarkup(stats.likedKitsByYear)
+          : `<p>No kits liked yet!</p>`
+      }
 
       <h4>Liked kits (${stats.likedKits.length})</h4>
 

--- a/src/style.css
+++ b/src/style.css
@@ -198,6 +198,23 @@ p {
   display: inline-block;
 }
 
+.kits-group {
+  margin-top: 16px;
+}
+
+.kits-group > .kits-gallery {
+  height: 80px;
+  margin: 8px 32px 16px;
+}
+
+.kits-group-label {
+  margin: 0 32px;
+  color: white;
+  font-size: 12px;
+  letter-spacing: 1px;
+  opacity: 0.7;
+}
+
 .about {
   margin: 32px;
   font-size: 18px;

--- a/test.ts
+++ b/test.ts
@@ -170,13 +170,20 @@ await run("seeded votes flow through to stats page", async () => {
     `top team populated after seeded likes (got ${JSON.stringify(topTeam)})`,
   );
   const likedImgs = (await view.evaluate(
-    "document.querySelectorAll('.kits-gallery')[0]?.querySelectorAll('img').length ?? 0",
+    "document.querySelectorAll('#stats > .kits-gallery')[0]?.querySelectorAll('img').length ?? 0",
   )) as number;
   check(likedImgs === 3, `liked gallery has 3 images (got ${likedImgs})`);
   const dislikedImgs = (await view.evaluate(
-    "document.querySelectorAll('.kits-gallery')[1]?.querySelectorAll('img').length ?? 0",
+    "document.querySelectorAll('#stats > .kits-gallery')[1]?.querySelectorAll('img').length ?? 0",
   )) as number;
   check(dislikedImgs === 1, `disliked gallery has 1 image (got ${dislikedImgs})`);
+  const teamGroupLabels = (await view.evaluate(
+    "Array.from(document.querySelectorAll('#stats .kits-group')).slice(0, 10).map(g => g.querySelector('.kits-group-label')?.textContent?.trim())",
+  )) as string[];
+  check(
+    teamGroupLabels.length > 0,
+    `liked kits grouped sections rendered (got ${teamGroupLabels.length} groups)`,
+  );
   check(
     (await collectInPageErrors()).length === 0,
     "no in-page errors on seeded /stats/",


### PR DESCRIPTION
## Summary
- Ports the Stats page grouping feature from #18 onto the current Bun + TypeScript + native-web stack (#18 targeted the old React stack and is no longer mergeable).
- Adds two new sections on `/stats/`: liked kits grouped by team (alphabetical) and by season (newest first), each row labelled with the group name and a count.
- Keeps the existing overall stats and full liked/disliked galleries untouched.

## Changes
- `src/Stats.ts` — aggregate `likedKitsByTeam` / `likedKitsByYear` in `getStats()`, add a `groupsMarkup()` helper, render the two new sections before the flat "Liked kits" gallery.
- `src/style.css` — new `.kits-group` / `.kits-group-label` rules.
- `test.ts` — scope the existing liked/disliked image-count assertions to `#stats > .kits-gallery` so the new nested group galleries don't shift the indices; add a sanity check that group sections render with labels.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (existing + new grouped-sections assertion)
- [ ] Manually: like kits across a few teams and seasons, open `/stats/`, confirm both grouped sections render with per-group counts
- [ ] Manually: with no likes yet, confirm "No kits liked yet!" shows under both new sections

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)